### PR TITLE
Fix example formatting

### DIFF
--- a/draft-prorock-spice-cwt-traceability-claims.md
+++ b/draft-prorock-spice-cwt-traceability-claims.md
@@ -173,18 +173,19 @@ Some claims below utilize GLUE Identifiers [GLUE].
 
 # Examples
 Product Information Example JWT Claims Set:
-```JSON
+
+```json
 {
-    "commodity_description": "Organic Blueberries, 12 oz containers",
-    "product_id": "nb-blueberries-001",
-    "country_of_origin": "CA",
-    "hs_code": "0810.40.0026",
-    "gross_weight": 5050,
-    "min_temperature": 0,
-    "max_temperature": 2,
-    "customs_value": 83335.0,
-    "currency_code": "USD",
-    "legal_jurisdiction": ["US", "CA"],
+  "commodity_description": "Organic Blueberries, 12 oz containers",
+  "product_id": "nb-blueberries-001",
+  "country_of_origin": "CA",
+  "hs_code": "0810.40.0026",
+  "gross_weight": 5050,
+  "min_temperature": 1,
+  "max_temperature": 3,
+  "customs_value": 83335,
+  "currency_code": "USD",
+  "legal_jurisdiction": ["US", "CA"]
 }
 ```
 

--- a/draft-prorock-spice-cwt-traceability-claims.md
+++ b/draft-prorock-spice-cwt-traceability-claims.md
@@ -182,7 +182,7 @@ Product Information Example JWT Claims Set:
   "hs_code": "0810.40.0026",
   "gross_weight": 5050,
   "min_temperature": 1,
-  "max_temperature": 3,
+  "max_temperature": 3.5,
   "customs_value": 83335,
   "currency_code": "USD",
   "legal_jurisdiction": ["US", "CA"]


### PR DESCRIPTION
I *believe* the problem was the lack of a blank line before the example.  (Did I say that I *hate* Markdown?)

Also, use a floating point number in the example.